### PR TITLE
Allow the minifyJs task to take multiple input files

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -18,7 +18,7 @@ import org.gradle.api.file.FileCollection
  */
 class JsMinifier {
 
-    void minifyJsFile(final File inputFile, final Set<File> externsFiles, final File outputFile, final CompilerOptions options,
+    void minifyJsFile(final Set<File> inputFiles, final Set<File> externsFiles, final File outputFile, final CompilerOptions options,
             final String warningLevel, final String compilationLevel) {
         Compiler compiler = new Compiler()
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
@@ -29,7 +29,9 @@ class JsMinifier {
             externs.addAll(externsFiles.collect() { JSSourceFile.fromFile(it) })
         }
         List<JSSourceFile> inputs = new ArrayList<JSSourceFile>()
-        inputs.add(JSSourceFile.fromFile(inputFile))
+        inputFiles.each { inputFile -> 
+          inputs.add(JSSourceFile.fromFile(inputFile))
+        }
         Result result = compiler.compile(externs, inputs, options)
         if (result.success) {
             outputFile.write(compiler.toSource())

--- a/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
@@ -33,7 +33,7 @@ class MinifyJsTask extends SourceTask {
     @TaskAction
     def run() {
         Set<File> externsFiles = project.closure.externs ? project.closure.externs.files : [] as Set<File>
-        MINIFIER.minifyJsFile(source.singleFile, externsFiles, dest as File,
+        MINIFIER.minifyJsFile(source.files, externsFiles, dest as File,
                 project.closure.compilerOptions, project.closure.warningLevel, project.closure.compilationLevel)
     }
 }


### PR DESCRIPTION
The minifyJs task can now use multiple input files instead of only one, so you can use the built-in dependency resolution of the closure compiler.
