### PR TITLE
Added ability to override default ignoreExitCode settings for JSHintTask

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/tasks/JsHintTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/JsHintTask.groovy
@@ -29,6 +29,8 @@ class JsHintTask extends SourceTask {
 
     @OutputFile def dest
 
+    Boolean ignoreExitCode = true
+
     File getDest() {
         project.file(dest)
     }
@@ -39,6 +41,6 @@ class JsHintTask extends SourceTask {
                 new File(project.buildDir, TMP_DIR), JSHINT_PATH)
         final List<String> args = [jshintJsFile.canonicalPath]
         args.addAll(source.files.collect { it.canonicalPath })
-        rhino.execute(args, [ignoreExitCode: true, out: new FileOutputStream(dest as File)])
+        rhino.execute(args, [ignoreExitCode: ignoreExitCode, out: new FileOutputStream(dest as File)])
     }
 }


### PR DESCRIPTION
I want the ability to have my builds fail if JSHint failed. So I modified the JSHint task to allow this to be overridden. I left ignoreExitCode defaulted to true, but now can be overridden in the task as such:

```
task lint(type: com.eriwen.gradle.js.tasks.JsHintTask) {
    ignoreExitCode = false
    source = javascript.source.dev.js.files
    dest = file("${buildDir}/jshint.out")
}
```
