### PR TITLE
Making ignoreExitCode for JSHintTask configurable

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/tasks/JsHintTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/JsHintTask.groovy
@@ -29,6 +29,8 @@ class JsHintTask extends SourceTask {
 
     @OutputFile def dest
 
+    def ignoreExitCode = true;
+
     File getDest() {
         project.file(dest)
     }
@@ -39,6 +41,6 @@ class JsHintTask extends SourceTask {
                 new File(project.buildDir, TMP_DIR), JSHINT_PATH)
         final List<String> args = [jshintJsFile.canonicalPath]
         args.addAll(source.files.collect { it.canonicalPath })
-        rhino.execute(args, [ignoreExitCode: true, out: new FileOutputStream(dest as File)])
+        rhino.execute(args, [ignoreExitCode: ignoreExitCode, out: new FileOutputStream(dest as File)])
     }
 }

--- a/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
+++ b/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
@@ -1,0 +1,81 @@
+package com.eriwen.gradle.js
+
+import org.gradle.api.Project
+import org.gradle.process.internal.ExecException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class JsHintTaskTest extends Specification {
+
+    @Rule TemporaryFolder dir = new TemporaryFolder();
+
+    Project project = ProjectBuilder.builder().build()
+    def task
+    def src
+
+    def setup() {
+        project.apply(plugin: JsPlugin)
+        task = project.tasks.jshint
+        src = dir.newFolder()
+        task.source = src
+        task.dest = dir.newFile()
+    }
+
+    def "build ignores result by default"() {
+        given:
+        addValidFile()
+        addInvalidFile()
+
+        when:
+        task.run();
+
+
+        then:
+        notThrown ExecException
+    }
+
+    def "build passes with only valid files"() {
+        given:
+        task.ignoreExitCode = false;
+        addValidFile()
+
+        when:
+        task.run();
+
+        then:
+        notThrown ExecException
+    }
+
+    def "build fails with invalid files"() {
+        given:
+        task.ignoreExitCode = false;
+        addValidFile()
+        addInvalidFile()
+
+        when:
+        task.run();
+
+        then:
+        ExecException e = thrown()
+    }
+
+
+    def addValidFile() {
+        addFile("valid.js", "var a = 5;")
+    }
+
+    def addInvalidFile() {
+        // no semicolon, jshint should fail
+        addFile("invalid.js", "var a = 5")
+    }
+
+    def addFile(name,contents) {
+        def file = new File(src,name)
+        file << contents
+    }
+
+}
+
+


### PR DESCRIPTION
I changed the JSHintTask to make the ignoreExitCode parameter configurable so you can optionally fail the build if jshint fails (it defaults to not failing, which is the current behavior). I also added tests for it.
