### PR TITLE
Adding Options Support To JsHintTask

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/JsHintExtension.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsHintExtension.groovy
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2012 Joe Fitzgerald
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.eriwen.gradle.js
+
+import org.gradle.api.tasks.Input
+
+class JsHintExtension {
+    public static final String NAME = 'jshint'
+
+    @Input LinkedHashMap<String, Object> options = []
+}

--- a/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
@@ -24,6 +24,7 @@ class JsPlugin implements Plugin<Project> {
     void apply(final Project project) {
         project.extensions.create(ClosureCompilerExtension.NAME, ClosureCompilerExtension)
         project.extensions.create(JsDocExtension.NAME, JsDocExtension)
+        project.extensions.create(JsHintExtension.NAME, JsHintExtension)
         project.extensions.create(Props2JsExtension.NAME, Props2JsExtension)
         project.extensions.create(JavaScriptExtension.NAME, JavaScriptExtension, project)
 
@@ -50,9 +51,9 @@ class JsPlugin implements Plugin<Project> {
         }
         project.dependencies {
             rhino 'org.mozilla:rhino:1.7R4'
-//            rhino 'com.google.code.gson:gson:2.2.1'
-            //add javaScript.gradlePublicJavaScriptRepository
-            //add javaScript.googleApisRepository
+            // rhino 'com.google.code.gson:gson:2.2.1'
+            // add javaScript.gradlePublicJavaScriptRepository
+            // add javaScript.googleApisRepository
         }
         // TODO: have 'check' depend on jshint
     }

--- a/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
+++ b/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
@@ -59,6 +59,20 @@ class JsHintTaskTest extends Specification {
         ExecException e = thrown()
     }
 
+    def "build writes to stdout and accepts options"() {
+        given:
+        task.ignoreExitCode = false
+        task.outputToStdOut = true
+        project.jshint.options = [scripturl: "true", laxcomma: "true"]
+
+        addValidFile()
+
+        when:
+        task.run()
+
+        then:
+        notThrown ExecException
+    }
 
     def addValidFile() {
         addFile("valid.js", "var a = 5;")


### PR DESCRIPTION
- Defaulting dest to a file, so that it is not required (e.g. when directing output to stdout)
- Permit JsHint output to be directed to stdout
- Adding support for options to be passed to JsHint
