### PR TITLE
minifyJs can now generate source maps

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -19,8 +19,10 @@ import org.gradle.api.GradleException
  */
 class JsMinifier {
 
-    void minifyJsFile(final Set<File> inputFiles, final Set<File> externsFiles, final File outputFile, final CompilerOptions options,
+    void minifyJsFile(final Set<File> inputFiles, final Set<File> externsFiles, final File outputFile, final File sourceMap, CompilerOptions options,
             final String warningLevel, final String compilationLevel) {
+        options = options ?: new CompilerOptions()
+        options.setSourceMapOutputPath(sourceMap?.path)
         Compiler compiler = new Compiler()
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
         WarningLevel level = WarningLevel.valueOf(warningLevel)
@@ -36,6 +38,11 @@ class JsMinifier {
         Result result = compiler.compile(externs, inputs, options)
         if (result.success) {
             outputFile.write(compiler.toSource())
+            if(sourceMap) {
+              def sourceMapContent = new StringBuffer()
+              result.sourceMap.appendTo(sourceMapContent, outputFile.name)
+              sourceMap.write(sourceMapContent.toString())
+            }
         } else {
         	String error = ""
             result.errors.each {

--- a/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
@@ -25,6 +25,7 @@ class MinifyJsTask extends SourceTask {
     private static final JsMinifier MINIFIER = new JsMinifier()
 
     @OutputFile def dest
+    @OutputFile def sourceMap
 
     File getDest() {
         project.file(dest)
@@ -33,7 +34,7 @@ class MinifyJsTask extends SourceTask {
     @TaskAction
     def run() {
         Set<File> externsFiles = project.closure.externs ? project.closure.externs.files : [] as Set<File>
-        MINIFIER.minifyJsFile(source.files, externsFiles, dest as File,
+        MINIFIER.minifyJsFile(source.files, externsFiles, dest as File, sourceMap as File,
                 project.closure.compilerOptions, project.closure.warningLevel, project.closure.compilationLevel)
     }
 }


### PR DESCRIPTION
Not much to say about this one except how it's used.

``` groovy
  minifyJs {
    source = javascript.source.dev.js
    dest = file("${buildDir}/app.js")
    sourceMap = file("${buildDir}/app.sourcemap.json")
}
```
