### PR TITLE
Using reflection to access gradle internal API.

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/source/internal/InternalGradle.java
+++ b/src/main/groovy/com/eriwen/gradle/js/source/internal/InternalGradle.java
@@ -3,7 +3,8 @@ package com.eriwen.gradle.js.source.internal;
 import org.gradle.api.Project;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.api.internal.project.ProjectInternal;
+
+import java.lang.reflect.Method;
 
 /**
  * Centralises access to internal Gradle API
@@ -11,14 +12,23 @@ import org.gradle.api.internal.project.ProjectInternal;
 public abstract class InternalGradle {
 
     public static Instantiator toInstantiator(Project project) {
-        return toProjectInternal(project).getServices().get(Instantiator.class);
-    }
-
-    public static ProjectInternal toProjectInternal(Project project) {
-        return ((ProjectInternal)project);
+        try {
+            Method getServices = project.getClass().getMethod("getServices");
+            Object serviceFactory = getServices.invoke(project);
+            Method get = serviceFactory.getClass().getMethod("get", Class.class);
+            return (Instantiator) get.invoke(serviceFactory, Instantiator.class);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public static FileResolver toFileResolver(Project project) {
-        return toProjectInternal(project).getFileResolver();
+        try {
+            Method getFileResolver =  project.getClass().getMethod("getFileResolver");
+            return (FileResolver) getFileResolver.invoke(project);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
+
 }


### PR DESCRIPTION
This commit fixes #83.

Now the methods in InternalGradle use reflection to access the internal gradle API. In case of fail (what should not occur) the IllegalStateException is thrown.
