### PR TITLE
Eliminate plugin registration of mavenCentral, moving to tests that use ...

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
@@ -47,9 +47,6 @@ class JsPlugin implements Plugin<Project> {
         project.configurations {
             rhino
         }
-        project.repositories {
-            mavenCentral()
-        }
         project.dependencies {
             rhino 'org.mozilla:rhino:1.7R3'
         }

--- a/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
+++ b/src/test/groovy/com/eriwen/gradle/js/JsHintTaskTest.groovy
@@ -17,6 +17,7 @@ class JsHintTaskTest extends Specification {
 
     def setup() {
         project.apply(plugin: JsPlugin)
+        project.repositories.mavenCentral()
         task = project.tasks.jshint
         src = dir.newFolder()
         dest = dir.newFile()

--- a/src/test/groovy/com/eriwen/gradle/js/RequireJsTaskTest.groovy
+++ b/src/test/groovy/com/eriwen/gradle/js/RequireJsTaskTest.groovy
@@ -16,6 +16,7 @@ class RequireJsTaskTest extends Specification {
 
     def setup() {
         project.apply(plugin: JsPlugin)
+        project.repositories.mavenCentral()
         task = project.tasks.requireJs
         src = dir.newFolder()
         task.source = src


### PR DESCRIPTION
Resolves Issue #71 - Hidden dependency on mavenCentral() repo

Rather than explicitly add a reference to mavenCentral while configuring the plugin, allow the repositories configured in the root build script to define the repositories.

Where repositories need to be specified for tests, declare them directly in the tests instead. Ideally these could be defined based on the root plugin build script or parameterized. When developing for the js plugin itself, these mavenCentral references may need to be changed to reflect local repositories while running the tests if, for instance, another mirror needs to be used in your environment. 
