### PR TITLE
Some improvements to Travis CI output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: groovy
-install: ./gradlew assemble
+install: ./gradlew resolveAllDependencies assemble
 script: ./gradlew clean build
 notifications:
   email: false
 branches:
   only:
     - master
-
+env:
+  global:
+  - TERM=dumb

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ test {
     testLogging {
         stackTraceFilters "truncate", "groovy"
         events "passed", "skipped", "failed"
+		exceptionFormat = 'full'
     }
 }
 
@@ -162,3 +163,9 @@ def getPomConfiguration() {
     }
 }
 
+// download dependencies all at once, keeps downloads out of travis output
+task resolveAllDependencies {
+	doLast {
+		configurations.all { it.resolve() }
+	}
+}


### PR DESCRIPTION
- Download everything in the install script so the main script isn't littered with downloads
- Set term so gradle doesn't try to update the display like an interactive one
- Show exception when a trest fails so you can see what went wrong
