### PR TITLE
Use latest version of jsdoc (3.3). Switch to use jsdoc distribution embe...

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/RhinoExec.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/RhinoExec.groovy
@@ -2,6 +2,7 @@ package com.eriwen.gradle.js
 
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
+import org.gradle.api.file.FileCollection
 
 /**
  * Utility for executing JS with Rhino.
@@ -11,6 +12,7 @@ import org.gradle.process.ExecResult
  */
 class RhinoExec {
     private static final String RHINO_MAIN_CLASS = 'org.mozilla.javascript.tools.shell.Main'
+
     Project project
 
     void execute(final Iterable<String> execargs, final Map<String, Object> options = [:]) {
@@ -18,16 +20,23 @@ class RhinoExec {
         final Boolean ignoreExitCode = options.get('ignoreExitCode', false).asBoolean()
         final OutputStream out = options.get('out', System.out) as OutputStream
         final String maxHeapSizeVal =  options.get('maxHeapSize', null)
+        final FileCollection classpathIn =  options.get('classpath', null)
 
         def execOptions = {
             main = RHINO_MAIN_CLASS
-            classpath = project.configurations.rhino
             args = ["-opt", "9"] + execargs
             workingDir = workingDirIn
             ignoreExitValue = ignoreExitCode
             standardOutput = out
             if (maxHeapSizeVal) {
                 maxHeapSize = maxHeapSizeVal
+            }
+
+            if (classpathIn) {
+              classpath = classpathIn
+            }
+            else {
+              classpath = project.configurations.rhino
             }
         }
 

--- a/src/main/groovy/com/eriwen/gradle/js/tasks/JsDocTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/JsDocTask.groovy
@@ -22,12 +22,13 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class JsDocTask extends SourceTask {
-    private static final String JSDOC_PATH = 'jsdoc.zip'
+    private static final String JSDOC_NAME = 'jsdoc-releases-3.3'
+    private static final String JSDOC_PATH = "${JSDOC_NAME}.zip"
     private static final String TMP_DIR = "tmp${File.separator}js"
     private static final ResourceUtil RESOURCE_UTIL = new ResourceUtil()
     private final RhinoExec rhino = new RhinoExec(project)
 
-    Iterable<String> modulePaths = ['node_modules', 'rhino_modules', '.']
+    Iterable<String> modulePaths = ['lib', 'node_modules', 'rhino', '.' ]
     Boolean debug = false
 
     @OutputDirectory def destinationDir
@@ -40,7 +41,7 @@ class JsDocTask extends SourceTask {
     def run() {
         final File zipFile = RESOURCE_UTIL.extractFileToDirectory(new File(project.buildDir, TMP_DIR), JSDOC_PATH)
         final File jsdocDir = RESOURCE_UTIL.extractZipFile(zipFile)
-        final String workingDir = "${jsdocDir.absolutePath}${File.separator}jsdoc"
+        final String workingDir = "${jsdocDir.absolutePath}${File.separator}${JSDOC_NAME}"
 
         final List<String> args = []
         if (debug) {
@@ -54,6 +55,6 @@ class JsDocTask extends SourceTask {
         args.addAll(['-d', (destinationDir as File).absolutePath])
         args.addAll(project.jsdoc.options.collect { it })
 
-        rhino.execute(args, [workingDir: workingDir])
+        rhino.execute(args, [workingDir: workingDir, classpath: project.files("${workingDir}${File.separator}rhino${File.separator}js.jar")])
     }
 }


### PR DESCRIPTION
...dded rhino.

Fixes Issue #68

The latest versions of jsdoc embed rhino, which this patch uses. This does not interfere with other uses of rhino (for instance by jshint).

The latest jsdoc release (referenced in this patch) is available at https://github.com/jsdoc3/jsdoc/archive/releases/3.3.zip

That zip will need to be placed as a replacement for the jsdoc.zip currently in src/main/resources