### PR TITLE
readme typo: convert string to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ props2js {
 ```groovy
 requireJs {
     source = javascript.source.dev.js.files
-    dest = "${buildDir}/out.js"
+    dest = file("${buildDir}/out.js")
     requirejs.buildprofile = new File("src/main/resources/requirejs-config.js")
 }
 ```


### PR DESCRIPTION
It's a simple change but it caused me a little time trying to find why had a cast error when there was no line number indicated in the error.

```
:requireJs

FAILURE: Build failed with an exception.

* What went wrong:
org.codehaus.groovy.runtime.GStringImpl cannot be cast to java.io.File

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 3.662 secs
```
