### PR TITLE
Per-task minifyJs compiler configuration

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -25,7 +25,7 @@ class JsMinifier {
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
         WarningLevel level = WarningLevel.valueOf(warningLevel)
         level.setOptionsForWarningLevel(options)
-        List<SourceFile> externs = CommandLineRunner.getDefaultExterns()
+        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions());
         if (externsFiles.size()) {
             externs.addAll(externsFiles.collect() { SourceFile.fromFile(it) })
         }

--- a/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsPlugin.groovy
@@ -48,6 +48,11 @@ class JsPlugin implements Plugin<Project> {
 
     void applyTasks(final Project project) {
         project.task('combineJs', type: CombineJsTask, group: 'Build', description: 'Combine many JavaScript files into one') {}
+        project.tasks.whenTaskAdded { task ->
+            if (task instanceof MinifyJsTask) {
+                task.extensions.create(ClosureCompilerExtension.NAME, ClosureCompilerExtension)
+            }
+        }
         project.task('minifyJs', type: MinifyJsTask, group: 'Build', description: 'Minify JavaScript using Closure Compiler') {}
         project.task('gzipJs', type: GzipJsTask, group: 'Build', description: 'GZip a given JavaScript file') {}
         project.task('jshint', type: JsHintTask, group: 'Verification', description: 'Analyze JavaScript sources with JSHint') {}

--- a/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/tasks/MinifyJsTask.groovy
@@ -15,7 +15,6 @@
  */
 package com.eriwen.gradle.js.tasks
 
-
 import com.eriwen.gradle.js.JsMinifier
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
@@ -34,8 +33,14 @@ class MinifyJsTask extends SourceTask {
 
     @TaskAction
     def run() {
-        Set<File> externsFiles = project.closure.externs ? project.closure.externs.files : [] as Set<File>
+        def buildSettings
+        if (this.closure) {
+            buildSettings = this.closure
+        } else {
+            buildSettings = project.closure
+        }
+        Set<File> externsFiles = buildSettings.externs ? buildSettings.externs.files : [] as Set<File>
         MINIFIER.minifyJsFile(source.files, externsFiles, dest as File, sourceMap as File,
-                project.closure.compilerOptions, project.closure.warningLevel, project.closure.compilationLevel)
+                buildSettings.compilerOptions, buildSettings.warningLevel, buildSettings.compilationLevel)
     }
 }


### PR DESCRIPTION
For large JS projects, the important case is having many MinifyJs tasks with different compiler settings. However, "closure" extension is currently defined on per-project level, such that settings for many MinifyJs tasks will be conflicting with each other.

I've tried to fix the problem by moving closure extension on task-level. (Not sure it is possible to implement a fallback to project-level settings.)

The provided test case should cover the situation with task interference.