### PR TITLE
set JaCoCo html report destination as File()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ jacocoTestReport {
     reports {
         xml.enabled false
         csv.enabled false
-        html.destination "${buildDir}/jacocoHtml"
+        html.destination file("${buildDir}/jacocoHtml")
     }
 }
 


### PR DESCRIPTION
There is and error during build project in TravisCI
```
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
```

Fixed set HTML report destination