### PR TITLE
Gradle 6.0 compatibility by removing deprecated API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'com.gradle.build-scan' version '1.8'
-    id "com.gradle.plugin-publish" version "0.9.4"
-    id "com.jfrog.bintray" version "1.6"
+    id 'com.gradle.build-scan' version '2.2.1'
+    id "com.gradle.plugin-publish" version "0.10.1"
+    id "com.jfrog.bintray" version "1.8.4"
 }
 apply plugin: 'groovy'
 apply plugin: 'maven'
@@ -10,8 +10,8 @@ apply plugin: 'signing'
 apply plugin: 'jacoco'
 apply plugin: 'project-report'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 defaultTasks 'clean', 'build'
 
@@ -21,8 +21,8 @@ ext.archivesBaseName = 'gradle-js-plugin'
 ext.isSnapshot = version.endsWith("-SNAPSHOT")
 
 buildScan {
-    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
-    licenseAgree = 'yes'
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 repositories {
@@ -143,7 +143,7 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.7.6.201602180812"
+    toolVersion = "0.8.3"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 
@@ -151,7 +151,7 @@ jacocoTestReport {
     reports {
         xml.enabled false
         csv.enabled false
-        html.destination "${buildDir}/jacocoHtml"
+        html.destination file("${buildDir}/jacocoHtml")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip

--- a/src/main/groovy/com/eriwen/gradle/js/source/internal/DefaultJavaScriptSourceSetContainer.java
+++ b/src/main/groovy/com/eriwen/gradle/js/source/internal/DefaultJavaScriptSourceSetContainer.java
@@ -4,6 +4,7 @@ import com.eriwen.gradle.js.source.JavaScriptSourceSet;
 import com.eriwen.gradle.js.source.JavaScriptSourceSetContainer;
 import org.gradle.api.Project;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -14,7 +15,7 @@ public class DefaultJavaScriptSourceSetContainer extends AbstractNamedDomainObje
     private final FileResolver fileResolver;
 
     public DefaultJavaScriptSourceSetContainer(Project project, Instantiator instantiator, FileResolver fileResolver) {
-        super(JavaScriptSourceSet.class, instantiator);
+        super(JavaScriptSourceSet.class, instantiator, CollectionCallbackActionDecorator.NOOP);
         this.project = project;
         this.instantiator = instantiator;
         this.fileResolver = fileResolver;


### PR DESCRIPTION
Fixes issue [#168](https://github.com/eriwen/gradle-js-plugin/issues/168).