### PR TITLE
Upgraded Closure Compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 idealib/
 build/
+bin/
 out/
 .gradle/
+.settings/
 *.iml
 *.ipr
 *.iws
 .idea/
 intellij
 gradle.properties
+.classpath
+.project

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ task createClasspathManifest {
 
 dependencies {
     compile gradleApi()
-    compile('com.google.javascript:closure-compiler:v20160208') {
+    compile('com.google.javascript:closure-compiler:v20191111') {
         exclude module: 'junit'
     }
     compile('io.jdev.html2js:html2js:0.1') {

--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -25,13 +25,13 @@ class JsMinifier {
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
         WarningLevel level = WarningLevel.valueOf(warningLevel)
         level.setOptionsForWarningLevel(options)
-        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions());
+        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions().getEnvironment());
         if (externsFiles.size()) {
-            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it) })
+            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it.getCanonicalPath()) })
         }
         List<SourceFile> inputs = new ArrayList<SourceFile>()
         inputFiles.each { inputFile -> 
-          inputs.add(SourceFile.fromFile(inputFile))
+          inputs.add(SourceFile.fromFile(inputFile.getCanonicalPath()))
         }
         Result result = compiler.compile(externs, inputs, options)
         if (result.success) {


### PR DESCRIPTION
minifyJs will throw errors in the event another dependency requires a newer version of Guarva.

This patch fixes those errors by upgrading to the latest closure compiler version.