### PR TITLE
Update Google Closure Compiler v20191111

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ targetCompatibility = 1.6
 
 defaultTasks 'clean', 'build'
 
-version = '2.14.1'
+version = '2.14.2'
 group = 'com.eriwen'
 ext.archivesBaseName = 'gradle-js-plugin'
 ext.isSnapshot = version.endsWith("-SNAPSHOT")
@@ -43,7 +43,7 @@ task createClasspathManifest {
 
 dependencies {
     compile gradleApi()
-    compile('com.google.javascript:closure-compiler:v20160208') {
+    compile('com.google.javascript:closure-compiler:v20191111') {
         exclude module: 'junit'
     }
     compile('io.jdev.html2js:html2js:0.1') {

--- a/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/js/JsMinifier.groovy
@@ -25,13 +25,13 @@ class JsMinifier {
         CompilationLevel.valueOf(compilationLevel).setOptionsForCompilationLevel(options)
         WarningLevel level = WarningLevel.valueOf(warningLevel)
         level.setOptionsForWarningLevel(options)
-        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions());
+        List<SourceFile> externs = CommandLineRunner.getBuiltinExterns(new CompilerOptions().getEnvironment());
         if (externsFiles.size()) {
-            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it) })
+            externs.addAll(externsFiles.collect() { SourceFile.fromFile(it.getPath()) })
         }
         List<SourceFile> inputs = new ArrayList<SourceFile>()
         inputFiles.each { inputFile -> 
-          inputs.add(SourceFile.fromFile(inputFile))
+          inputs.add(SourceFile.fromFile(inputFile.getPath()))
         }
         Result result = compiler.compile(externs, inputs, options)
         if (result.success) {


### PR DESCRIPTION
Update Google Closure Compiler version from v20160208 to v20191111.
This support ECMASCRIPT_2019 and older to set in lenguageIn